### PR TITLE
change install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Send HPGL code on our Roland DXY plotters through a web interface.
 
 ### Clone repository
 
-`git clone git@github.com:LgHS/hpgl-sender.git`
+`git clone https://github.com/LgHS/hpgl-sender.git
 
 ## Run server
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Send HPGL code on our Roland DXY plotters through a web interface.
 
 ### Clone repository
 
-`git clone https://github.com/LgHS/hpgl-sender.git
+`git clone https://github.com/LgHS/hpgl-sender.git'
 
 ## Run server
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Send HPGL code on our Roland DXY plotters through a web interface.
 
 ### Clone repository
 
-`git clone https://github.com/LgHS/hpgl-sender.git'
+`git clone https://github.com/LgHS/hpgl-sender.git`
 
 ## Run server
 


### PR DESCRIPTION
Github is getting sensitive to SSL. This would be an easy way to get around the issue.